### PR TITLE
Campaign edit link user17

### DIFF
--- a/app/controllers/campaigns/players_controller.rb
+++ b/app/controllers/campaigns/players_controller.rb
@@ -4,7 +4,7 @@ class Campaigns::PlayersController < ApplicationController
     if params[:order_by].nil?
       @players = @campaign.players
     else
-      @players = @campaign.players.order(params[:order_by])
+      @players = @campaign.order_players(params[:order_by])
     end
   end
 

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -8,4 +8,8 @@ class Campaign < ApplicationRecord
   def num_of_players
     players.size
   end
+
+  def order_players(param)
+    players.order(param)
+  end
 end

--- a/app/views/campaigns/index.html.erb
+++ b/app/views/campaigns/index.html.erb
@@ -3,5 +3,6 @@
 <% @campaigns.each do |campaign| %>
   <h2><%= link_to campaign.campaign_name, "/campaigns/#{campaign.id}" %></h2>
       <p class="tab">- Created: <%= campaign.created_at %></p>
+      <p> <%= button_to "Update #{campaign.campaign_name}", "/campaigns/#{campaign.id}/edit", method: :get %></p>
 <% end %>
 <%= link_to 'New Campaign', '/campaigns/new' %>

--- a/app/views/campaigns/show.html.erb
+++ b/app/views/campaigns/show.html.erb
@@ -1,8 +1,8 @@
 <h1><%= @campaign.campaign_name%></h1>
 <hr>
+<%= link_to "#{@campaign.campaign_name} Players", "/campaigns/#{@campaign.id}/players" %>
 <p>Name of DM: <%= @campaign.dm_name %>
 <p>First DM: <%= @campaign.first_dm %>
 <p>Difficult Rating: <%= @campaign.difficult_rating %>
 <p>Total Players: <%= @num_of_players %></p>
-<p> <%= link_to "Update Campaign", "/campaigns/#{@campaign.id}/edit" %></p>
-<%= link_to "#{@campaign.campaign_name} Players", "/campaigns/#{@campaign.id}/players", class: 'button' %>
+<p> <%= button_to "Update Campaign", "/campaigns/#{@campaign.id}/edit", method: :get %></p>

--- a/spec/features/campaigns/index_spec.rb
+++ b/spec/features/campaigns/index_spec.rb
@@ -67,5 +67,24 @@ RSpec.describe '/campaigns', type: :feature do
 
       expect(page).to have_current_path("/campaigns/#{@waterdeep.id}")
     end
+
+    it 'I see a link next to every campaign to edit that campaigns info' do
+
+      visit '/campaigns'
+
+      expect(page).to have_button('Update Waterdeep')
+      expect(page).to have_button('Update Dragon Heist')
+
+      click_button('Update Waterdeep')
+
+      expect(page).to have_current_path("/campaigns/#{@waterdeep.id}/edit")
+
+      fill_in("DM Name:", with: 'Carl')
+      click_button('Update')
+
+      expect(page).to have_current_path("/campaigns/#{@waterdeep.id}")
+      expect(page).to have_content('Carl')
+      expect(page).to_not have_content('Thomas')
+    end
   end
 end

--- a/spec/features/campaigns/show_spec.rb
+++ b/spec/features/campaigns/show_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe '/campaigns/:id', type: :feature do
 
     it 'I see a link to update the Campaign, "Update Campaign"' do
       visit "/campaigns/#{@dragon_heist.id}"
-      click_link("Update Campaign")
+      click_button("Update Campaign")
 
       expect(page).to have_current_path("/campaigns/#{@dragon_heist.id}/edit")
 # save_and_open_page

--- a/spec/models/campaign_spec.rb
+++ b/spec/models/campaign_spec.rb
@@ -15,19 +15,27 @@ RSpec.describe Campaign, type: :model do
   end
 
   describe 'instance methods' do
-    it '::order_by_created_at' do
-      
-      expect(Campaign.order_by_created_at).to eq([@waterdeep, @dragon_heist])
-      
-      @dragon_heist.created_at = "2012-02-27 00:00:00"
-      @dragon_heist.save
-
-      expect(Campaign.order_by_created_at).to eq([@dragon_heist, @waterdeep])
+    describe '::order_by_created_at' do
+      it 'can order campaigns by their created_at date' do
+        
+        expect(Campaign.order_by_created_at).to eq([@waterdeep, @dragon_heist])
+        
+        @dragon_heist.created_at = "2012-02-27 00:00:00"
+        @dragon_heist.save
+        
+        expect(Campaign.order_by_created_at).to eq([@dragon_heist, @waterdeep])
+      end
     end
-
-    it '#num_of_players' do
-      
-      expect(@dragon_heist.num_of_players).to eq(3)
+    describe '#num_of_players' do
+      it 'can return an integer of the number of players for a campaign' do
+        expect(@dragon_heist.num_of_players).to eq(3)
+      end
+    end
+    
+    describe '#order_players()' do
+      it 'can order players in a campaign by their player_name' do
+        expect(@dragon_heist.order_players('player_name')).to eq([@alec, @andrew, @crow])
+      end
     end
   end
 end


### PR DESCRIPTION
Refactored the campaign players order feature by adding a model method #order_players to Campaign. 
Changed the update link in the campaign show page to a button called Update.
Added feature to the campaign show page where each campaign has an update button personalized for each campaign with their name. 