### PR TITLE
Delete campaign user19

### DIFF
--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -26,6 +26,13 @@ class CampaignsController < ApplicationController
     redirect_to "/campaigns/#{campaign.id}"
   end
 
+  def destroy
+    campaign = Campaign.find(params[:id])
+    campaign.players.destroy_all
+    campaign.destroy
+    redirect_to "/campaigns"
+  end
+
   private
   def campaign_params
     params.permit(:campaign_name, :dm_name, :first_dm, :difficult_rating)

--- a/app/views/campaigns/show.html.erb
+++ b/app/views/campaigns/show.html.erb
@@ -6,3 +6,5 @@
 <p>Difficult Rating: <%= @campaign.difficult_rating %>
 <p>Total Players: <%= @num_of_players %></p>
 <p> <%= button_to "Update Campaign", "/campaigns/#{@campaign.id}/edit", method: :get %></p>
+<br>
+<%= button_to "Delete", "/campaigns/#{@campaign.id}", method: :delete %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   post '/campaigns', to: 'campaigns#create'
   get '/campaigns/:id/edit', to: 'campaigns#edit'
   patch '/campaigns/:id', to: 'campaigns#update'
+  delete '/campaigns/:id', to: 'campaigns#destroy'
   get '/players', to: 'players#index'
   get '/players/:id', to: 'players#show'
   get '/players/:id/edit', to: 'players#edit'

--- a/spec/features/campaigns/show_spec.rb
+++ b/spec/features/campaigns/show_spec.rb
@@ -52,5 +52,21 @@ RSpec.describe '/campaigns/:id', type: :feature do
 
       expect(page).to have_current_path("/campaigns/#{@dragon_heist.id}/players")
     end
+
+    it 'I see a button next to the campaign to delete the campaign' do
+      visit "/campaigns/#{@dragon_heist.id}"
+
+      click_button("Delete")
+
+    end
+
+    it 'Whe I click the delete button I am redirected to /campaigns and the campaign is not there' do
+      visit "/campaigns/#{@dragon_heist.id}"
+
+      click_button("Delete")
+
+      expect(current_path).to eq("/campaigns")
+      expect(page).to_not have_content(@dragon_heist.campaign_name)
+    end
   end
 end


### PR DESCRIPTION
Added a delete button to the campaign show page that when clicked delete the campaign record along with all the players associated with that campaign.  
After click, redirected back to the campaigns index page. 