### PR TITLE
Campaign players lvl sort user21

### DIFF
--- a/app/controllers/campaigns/players_controller.rb
+++ b/app/controllers/campaigns/players_controller.rb
@@ -1,11 +1,7 @@
 class Campaigns::PlayersController < ApplicationController
   def index
     @campaign = Campaign.find(params[:campaign_id])
-    if params[:order_by].nil?
-      @players = @campaign.players
-    else
-      @players = @campaign.order_players(params[:order_by])
-    end
+    @players = @campaign.retrieve_players(params)
   end
 
   def new

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -9,7 +9,21 @@ class Campaign < ApplicationRecord
     players.size
   end
 
-  def order_players(param)
-    players.order(param)
+  def retrieve_players(params)
+    if !params[:order_by].nil?
+      order_players(params)
+    elsif !params[:level].nil?
+      sort_players_by_lvl(params)
+    else
+      players
+    end
+  end
+
+  def order_players(params)
+    players.order(params[:order_by])
+  end
+
+  def sort_players_by_lvl(params)
+    players.where('char_lvl > ?', params[:level])
   end
 end

--- a/app/views/campaigns/new.html.erb
+++ b/app/views/campaigns/new.html.erb
@@ -6,7 +6,7 @@
   <%= form.label :dm_name, "DM Name:" %>
   <%= form.text_field :dm_name %><br><br>
   <%= form.label :first_dm, "First DM:" %>
-  <%= form.text_field :first_dm %><br><br>
+  <%= form.select :first_dm, [true, false] %><br><br>
   <%= form.label :difficult_rating, "Difficulty Rating:" %>
   <%= form.text_field :difficult_rating %><br><br>
   <%= form.submit 'Create' %>

--- a/app/views/campaigns/players/index.html.erb
+++ b/app/views/campaigns/players/index.html.erb
@@ -8,6 +8,12 @@
 <%= button_to "Update #{player.player_name}", "/players/#{player.id}/edit", method: :get %>
 <% end %>
 <br>
+<%= button_to 'Add Player', "/campaigns/#{@campaign.id}/players/new", method: :get %>
+<br><br>
 <%= link_to 'Sort Names', "/campaigns/#{@campaign.id}/players?order_by=player_name", method: :get %>
 <br><br>
-<%= button_to 'Add Player', "/campaigns/#{@campaign.id}/players/new", method: :get %>
+<%= form_with url: "/campaigns/#{@campaign.id}/players", method: :get, local: true do |form| %>
+<%= form.label :level, "Character lvl:" %>
+<%= form.text_field :level %>
+<%= form.submit "Only show players above selected lvl" %>
+<% end %>

--- a/app/views/campaigns/players/new.html.erb
+++ b/app/views/campaigns/players/new.html.erb
@@ -7,7 +7,7 @@
   <%= form.label :character_name, "Character Name:" %>
   <%= form.text_field :character_name %><br><br>
   <%= form.label :new_player, "New Player:" %>
-  <%= form.text_field :new_player %><br><br>
+  <%= form.select :new_player, [true, false] %><br><br>
   <%= form.label :char_lvl, "Character Level:" %>
   <%= form.text_field :char_lvl %><br><br>
   <%= form.submit 'Add Player' %>

--- a/spec/features/campaigns/new_spec.rb
+++ b/spec/features/campaigns/new_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe '/campaigns/new', type: :feature do
 
     fill_in 'Campaign Name:', with: 'Tales from the Infinite Staircase'
     fill_in 'DM Name:', with: 'Tony'
-    fill_in 'First DM:', with: false
+    select false, from: "First DM:"
     fill_in 'Difficulty Rating:', with: 5
     click_button("Create")
 

--- a/spec/features/campaigns/players/index_spec.rb
+++ b/spec/features/campaigns/players/index_spec.rb
@@ -73,10 +73,23 @@ RSpec.describe '/campaigns/:campaign_id/players', type: :feature do
     end
 
     it 'I see a button next to every player to edit their information' do
-      visit '/players'
+      visit "/campaigns/#{@waterdeep.id}/players"
       click_button("Update #{@crow.player_name}")
 
       expect(page).to have_current_path("/players/#{@crow.id}/edit")
+    end
+
+    it 'has a form to show players above char_lvl' do
+      visit "/campaigns/#{@waterdeep.id}/players"
+
+      fill_in "Character lvl:", with: 4
+
+      click_button('Only show players above selected lvl')
+
+      expect(current_path).to eq("/campaigns/#{@waterdeep.id}/players")
+      expect(page).to have_content(@margaret.player_name)
+      expect(page).to_not have_content(@crow.player_name)
+      expect(page).to_not have_content(@angel.player_name)
     end
   end
 end

--- a/spec/features/campaigns/players/new_spec.rb
+++ b/spec/features/campaigns/players/new_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe '/campaigns/:campaign_id/players/new', type: :feature do
 
   describe 'When I visit a campaigns players index page I see a link to create a new player' do
     it 'I click on the link to create a new player and fill out new player info' do
-      
+
       visit "/campaigns/#{@waterdeep.id}/players"
       click_button('Add Player')
 
@@ -15,7 +15,7 @@ RSpec.describe '/campaigns/:campaign_id/players/new', type: :feature do
 
       fill_in('Player Name:', with: 'Starsky')
       fill_in('Character Name:', with: 'Doggy Doggerston')
-      fill_in('New Player:', with: true)
+      select true, :from => "New Player:"
       fill_in('Character Level:', with: 1)
 
       click_button("Add Player")

--- a/spec/models/campaign_spec.rb
+++ b/spec/models/campaign_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Campaign, type: :model do
     @waterdeep = Campaign.create!(campaign_name: 'Waterdeep', dm_name: 'Thomas', first_dm: true, difficult_rating: 5)
     @dragon_heist = Campaign.create!(campaign_name: 'Dragon Heist', dm_name: 'Dan', first_dm: false, difficult_rating: 4,)
 
-    @crow = @dragon_heist.players.create!(player_name: 'Crow', character_name: 'Nocturia', new_player: true, char_lvl: 2)
+    @crow = @dragon_heist.players.create!(player_name: 'Crow', character_name: 'Nocturia', new_player: true, char_lvl: 3)
     @alec = @dragon_heist.players.create!(player_name: 'Alec', character_name: 'Hockly', new_player: false, char_lvl: 2)
     @andrew = @dragon_heist.players.create!(player_name: 'Andrew', character_name: 'Georgio Clunamous', new_player: false, char_lvl: 2)
   end
@@ -34,7 +34,20 @@ RSpec.describe Campaign, type: :model do
     
     describe '#order_players()' do
       it 'can order players in a campaign by their player_name' do
-        expect(@dragon_heist.order_players('player_name')).to eq([@alec, @andrew, @crow])
+        expect(@dragon_heist.order_players({order_by: 'player_name'})).to eq([@alec, @andrew, @crow])
+      end
+    end
+
+    describe '#sort_players_by_lvl' do
+      it 'can select players above a certain char_lvl' do
+        expect(@dragon_heist.sort_players_by_lvl({level: 2})).to eq([@crow])
+      end
+    end
+
+    describe '#retrieve_players' do
+      it 'can retrieve players by what is set in the params' do
+        expect(@dragon_heist.retrieve_players({order_by: 'player_name'})).to eq([@alec, @andrew, @crow])
+        expect(@dragon_heist.retrieve_players({level: 2})).to eq([@crow])
       end
     end
   end


### PR DESCRIPTION
Added feature to campaign players index page with a form to input a player lvl and then return a list of the players with characters above that lvl.  
Added a method in the campaign model to retrieve a list of players based on criteria of (player characters above a certain lvl), order players alphabetically, or all players for that campaign). 
Testing is still %100 covered. 